### PR TITLE
Add config so that markdown renders on pipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     author_email='bradleylamar@gmail.com',
     description='Tools to work with USFM references',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=find_packages(exclude=('tests',)),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
This change should cause Pypi to render the Markdown from the README, instead of just displaying it (as it does currently; see screenshot): 

![image](https://user-images.githubusercontent.com/575773/44747621-3ba09080-aad3-11e8-8d53-07f24dd79dfd.png)


Per: https://github.com/di/markdown-description-example and https://packaging.python.org/guides/making-a-pypi-friendly-readme/